### PR TITLE
interface styles: invalidate healthbar cache on shutdown

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/interfacestyles/InterfaceStylesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/interfacestyles/InterfaceStylesPlugin.java
@@ -94,6 +94,8 @@ public class InterfaceStylesPlugin extends Plugin
 			removeGameframe();
 			healthBarOverride = null;
 			client.setHealthBarOverride(null);
+			NodeCache heathBarCache = client.getHealthBarCache();
+			heathBarCache.reset(); // invalidate healthbar cache so padding resets
 		});
 	}
 


### PR DESCRIPTION
The padding needs to be reset for the normal healthbar